### PR TITLE
Separator

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -84,6 +84,7 @@ log_eval <- function(expr, level = TRACE, multiline = FALSE) {
 #' @examples
 #' log_separator()
 #' log_separator(ERROR, separator = '!', width = 60)
+#' @seealso \code{\link{log_with_separator}}
 log_separator <- function(level = INFO, namespace = NA_character_, separator = '=', width = 80) {
     log_level(
         paste(rep(separator, width - 23 - nchar(attr(level, 'level'))), collapse = ''),
@@ -108,6 +109,7 @@ log_separator <- function(level = INFO, namespace = NA_character_, separator = '
 #'   'eventually wrap into a multi-line message for our quite nice demo :wow:'),
 #'   width = 60)
 #' log_with_separator('Boo!', level = FATAL)
+#' @seealso \code{\link{log_separator}}
 log_with_separator <- function(..., level = INFO, namespace = NA_character_, separator = '=', width = 80) {
 
     log_separator(level = level, separator = separator, width = width, namespace = namespace)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -83,7 +83,7 @@ log_eval <- function(expr, level = TRACE, multiline = FALSE) {
 #' @export
 #' @examples
 #' log_separator()
-#' log_separator(ERROR, '!', width = 60)
+#' log_separator(ERROR, separator = '!', width = 60)
 log_separator <- function(level = INFO, namespace = NA_character_, separator = '=', width = 80) {
     log_level(
         paste(rep(separator, width - 23 - nchar(attr(level, 'level'))), collapse = ''),

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -84,10 +84,11 @@ log_eval <- function(expr, level = TRACE, multiline = FALSE) {
 #' @examples
 #' log_separator()
 #' log_separator(ERROR, '!', width = 60)
-log_separator <- function(level = INFO, separator = '=', width = 80) {
+log_separator <- function(level = INFO, namespace = NA_character_, separator = '=', width = 80) {
     log_level(
         paste(rep(separator, width - 23 - nchar(attr(level, 'level'))), collapse = ''),
-        level = level)
+        level = level,
+        namespace = namespace)
 }
 
 

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -110,7 +110,7 @@ log_separator <- function(level = INFO, namespace = NA_character_, separator = '
 #' log_with_separator('Boo!', level = FATAL)
 log_with_separator <- function(..., level = INFO, namespace = NA_character_, separator = '=', width = 80) {
 
-    log_separator(level = level, separator = separator, width = width)
+    log_separator(level = level, separator = separator, width = width, namespace = namespace)
 
     message <- do.call(eval(log_formatter()), list(...))
     message <- strwrap(message, width - 23 - nchar(attr(level, 'level')) - 4)
@@ -120,9 +120,9 @@ log_with_separator <- function(..., level = INFO, namespace = NA_character_, sep
             paste(rep(' ', width - 23 - nchar(attr(level, 'level')) - 4 - nchar(m)), collapse = ''),
             ' ', separator)
     })
-    log_level(skip_formatter(message), level = level)
+    log_level(skip_formatter(message), level = level, namespace = namespace)
 
-    log_separator(level = level, separator = separator, width = width)
+    log_separator(level = level, separator = separator, width = width, namespace = namespace)
 
 }
 

--- a/man/log_separator.Rd
+++ b/man/log_separator.Rd
@@ -23,4 +23,6 @@ Logs a long line to stand out from the console
 log_separator()
 log_separator(ERROR, separator = '!', width = 60)
 }
+\seealso{
+\code{\link{log_with_separator}}
 }

--- a/man/log_separator.Rd
+++ b/man/log_separator.Rd
@@ -4,10 +4,13 @@
 \alias{log_separator}
 \title{Logs a long line to stand out from the console}
 \usage{
-log_separator(level = INFO, separator = "=", width = 80)
+log_separator(level = INFO, namespace = NA_character_,
+  separator = "=", width = 80)
 }
 \arguments{
 \item{level}{log level, see \code{\link{log_levels}} for more details}
+
+\item{namespace}{string referring to the \code{logger} environment / config to be used to override the target of the message record to be used instead of the default namespace, which is defined by the R package name from which the logger was called, and falls back to a common, global namespace.}
 
 \item{separator}{character to be used as a separator}
 
@@ -18,5 +21,6 @@ Logs a long line to stand out from the console
 }
 \examples{
 log_separator()
-log_separator(ERROR, '!', width = 60)
+log_separator(ERROR, separator = '!', width = 60)
+}
 }

--- a/man/log_with_separator.Rd
+++ b/man/log_with_separator.Rd
@@ -34,3 +34,6 @@ log_with_separator(paste(
   width = 60)
 log_with_separator('Boo!', level = FATAL)
 }
+\seealso{
+\code{\link{log_separator}}
+}


### PR DESCRIPTION
Hi,

First of all, thanks for this package :)

I noticed `log_with_separator` did not use its namespace argument and `log_separator` didn't have a namespace argument, as it seems to be the case for most other `log_` functions. 

This PR "fixes" those points.