### PR TITLE
Evaluate arguments only if they are to be logged

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -272,13 +272,18 @@ log_level <- function(level, ..., namespace = NA_character_,
     }
 
     definitions <- get_logger_definitions(namespace, .topenv = .topenv)
+    level <- validate_log_level(level)
 
     for (definition in definitions) {
 
+        if (level > definition$threshold) {
+            next
+        }
+        
         log_fun <- do.call(logger, definition)
         log_arg <- list(...)
 
-        log_arg$level <- validate_log_level(level)
+        log_arg$level <- level
         log_arg$.logcall <- .logcall
         log_arg$.topcall  <- if(!is.null(.topcall)) {
             .topcall


### PR DESCRIPTION
This PR proposes that arguments passed as `...` are only evaluated if they are to be logged.

**Motivation and background**
  
  This increases performance if logs on certain levels (e.g. `TRACE`) require non-negligible time to produce. One practical example is logging the hashes of files being read for reconciliation purposes. Currently, if we use:
  
  ```logger::log_trace("md5=", tools::md5sum(filePath))```

the `md5sum` will be calculated regardless of the threshold, increasing runtime even if the threshold is lower than that for `TRACE` and nothing will be logged. 

After the change, the arguments would be evaluated only if they really are to be logged and therefore are needed.