### PR TITLE
Fix typo in validate_log_level()

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -351,7 +351,7 @@ validate_log_level <- function(level) {
     if (is.character(level) & level %in% log_levels_supported) {
         return(get(level))
     }
-    stop('Invalid log level', )
+    stop('Invalid log level')
 }
 
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -20,7 +20,7 @@ test_that('except helper', {
 test_that('validate_log_level', {
     expect_equal(logger:::validate_log_level(ERROR), ERROR)
     expect_equal(logger:::validate_log_level('ERROR'), ERROR)
-    expect_error(logger:::validate_log_level('FOOBAR'))
+    expect_error(logger:::validate_log_level('FOOBAR'), 'log level')
 })
 
 ## reset settings


### PR DESCRIPTION
Easy fix (typo): Changed `stop('Invalid log level', )` to `stop('Invalid log level')` and updated the corresponding test for `validate_log_level()`

Current version:
```r
> logger:::validate_log_level('FOOBAR')
Error in stop("Invalid log level", ) : 
  argument is missing, with no default
```

After PR:
```r
> logger:::validate_log_level('FOOBAR')
Error in logger:::validate_log_level("FOOBAR") : Invalid log level
```