### PR TITLE
Add log rotation to appender_tee

### DIFF
--- a/R/appenders.R
+++ b/R/appenders.R
@@ -139,22 +139,21 @@ appender_file <- function(file, append = TRUE, max_lines = Inf, max_bytes = Inf,
 
 #' Append log messages to a file and stdout as well
 #'
-#' This appends log messages to both console and a file. The same rotation options are available as in \code{appender_file()}.
+#' This appends log messages to both console and a file. The same rotation options are available as in \code{\link{appender_file}}.
 #' @inheritParams appender_file
 #' @export
 #' @return function taking \code{lines} argument
 #' @seealso This is generator function for \code{\link{log_appender}}, for alternatives, see eg \code{\link{appender_console}}, \code{\link{appender_file}}, \code{\link{appender_slack}}, \code{\link{appender_pushbullet}}, \code{\link{appender_telegram}}, \code{\link{appender_syslog}}, \code{\link{appender_kinesis}} and \code{\link{appender_async}} for evaluate any \code{\link{log_appender}} function in a background process.
 appender_tee <- function(file, append = TRUE, max_lines = Inf, max_bytes = Inf, max_files = 1L) {
-  force(append)
-  force(max_lines)
-  force(max_bytes)
-  force(max_files)
-  structure(
-    function(lines) {
-      appender_console(lines)
-      appender_file(file, append, max_lines, max_bytes, max_files)(lines)
-    }, generator = deparse(match.call())
-  )
+    force(append)
+    force(max_lines)
+    force(max_bytes)
+    force(max_files)
+    structure(
+        function(lines) {
+            appender_console(lines)
+            appender_file(file, append, max_lines, max_bytes, max_files)(lines)
+        }, generator = deparse(match.call()))
 }
 
 

--- a/R/appenders.R
+++ b/R/appenders.R
@@ -138,17 +138,23 @@ appender_file <- function(file, append = TRUE, max_lines = Inf, max_bytes = Inf,
 
 
 #' Append log messages to a file and stdout as well
+#'
+#' This appends log messages to both console and a file. The same rotation options are available as in \code{appender_file()}.
 #' @inheritParams appender_file
 #' @export
 #' @return function taking \code{lines} argument
 #' @seealso This is generator function for \code{\link{log_appender}}, for alternatives, see eg \code{\link{appender_console}}, \code{\link{appender_file}}, \code{\link{appender_slack}}, \code{\link{appender_pushbullet}}, \code{\link{appender_telegram}}, \code{\link{appender_syslog}}, \code{\link{appender_kinesis}} and \code{\link{appender_async}} for evaluate any \code{\link{log_appender}} function in a background process.
-appender_tee <- function(file, append = TRUE) {
-    force(append)
-    structure(
-        function(lines) {
-            appender_console(lines)
-            appender_file(file)(lines)
-        }, generator = deparse(match.call()))
+appender_tee <- function(file, append = TRUE, max_lines = Inf, max_bytes = Inf, max_files = 1L) {
+  force(append)
+  force(max_lines)
+  force(max_bytes)
+  force(max_files)
+  structure(
+    function(lines) {
+      appender_console(lines)
+      appender_file(file, append, max_lines, max_bytes, max_files)(lines)
+    }, generator = deparse(match.call())
+  )
 }
 
 

--- a/man/appender_tee.Rd
+++ b/man/appender_tee.Rd
@@ -4,18 +4,30 @@
 \alias{appender_tee}
 \title{Append log messages to a file and stdout as well}
 \usage{
-appender_tee(file, append = TRUE)
+appender_tee(
+  file,
+  append = TRUE,
+  max_lines = Inf,
+  max_bytes = Inf,
+  max_files = 1L
+)
 }
 \arguments{
 \item{file}{path}
 
 \item{append}{boolean passed to \code{cat} defining if the file should be overwritten with the most recent log message instead of appending}
+
+\item{max_lines}{numeric specifying the maximum number of lines allowed in a file before rotating}
+
+\item{max_bytes}{numeric specifying the maximum number of bytes allowed in a file before rotating}
+
+\item{max_files}{integer specifying the maximum number of files to be used in rotation}
 }
 \value{
 function taking \code{lines} argument
 }
 \description{
-Append log messages to a file and stdout as well
+This appends log messages to both console and a file. The same rotation options are available as in \code{appender_file()}.
 }
 \seealso{
 This is generator function for \code{\link{log_appender}}, for alternatives, see eg \code{\link{appender_console}}, \code{\link{appender_file}}, \code{\link{appender_slack}}, \code{\link{appender_pushbullet}}, \code{\link{appender_telegram}}, \code{\link{appender_syslog}}, \code{\link{appender_kinesis}} and \code{\link{appender_async}} for evaluate any \code{\link{log_appender}} function in a background process.

--- a/man/appender_tee.Rd
+++ b/man/appender_tee.Rd
@@ -27,7 +27,7 @@ appender_tee(
 function taking \code{lines} argument
 }
 \description{
-This appends log messages to both console and a file. The same rotation options are available as in \code{appender_file()}.
+This appends log messages to both console and a file. The same rotation options are available as in \code{\link{appender_file}}.
 }
 \seealso{
 This is generator function for \code{\link{log_appender}}, for alternatives, see eg \code{\link{appender_console}}, \code{\link{appender_file}}, \code{\link{appender_slack}}, \code{\link{appender_pushbullet}}, \code{\link{appender_telegram}}, \code{\link{appender_syslog}}, \code{\link{appender_kinesis}} and \code{\link{appender_async}} for evaluate any \code{\link{log_appender}} function in a background process.


### PR DESCRIPTION
I have modified `appender_tee()` to allow passing parameters for log file rotation.