### PR TITLE
Remove duplicated condition after it being logged

### DIFF
--- a/R/hooks.R
+++ b/R/hooks.R
@@ -37,20 +37,20 @@ log_messages <- function() {
 #' Injects a logger call to standard warnings
 #'
 #' This function uses \code{trace} to add a \code{log_warn} function call when \code{warning} is called to log the warning messages with the \code{logger} layout and appender.
-#' 
-#' @param muffle if TRUE, the warning are not shown after being logged
-#' 
+#' @param muffle if TRUE, the warning is not shown after being logged
 #' @export
 #' @examples \dontrun{
 #' log_warnings()
 #' for (i in 1:5) { Sys.sleep(runif(1)); warning(i) }
 #' }
-log_warnings <- function(muffle=getOption("logger_muffle_warnings", FALSE)) {
+log_warnings <- function(muffle = getOption('logger_muffle_warnings', FALSE)) {
     if (R.Version()$major >= 4) {
         globalCallingHandlers(
             warning = function(m) {
                 logger::log_warn(m$message)
-                if(isTRUE(muffle)) invokeRestart("muffleWarning")
+                if (isTRUE(muffle)) {
+                    invokeRestart('muffleWarning')
+                }
             }
         )
     } else {
@@ -67,20 +67,20 @@ log_warnings <- function(muffle=getOption("logger_muffle_warnings", FALSE)) {
 #' Injects a logger call to standard errors
 #'
 #' This function uses \code{trace} to add a \code{log_error} function call when \code{stop} is called to log the error messages with the \code{logger} layout and appender.
-#' 
-#' @param muffle if TRUE, the errors are not thrown after being logged
-#' 
+#' @param muffle if TRUE, the error is not thrown after being logged
 #' @export
 #' @examples \dontrun{
 #' log_errors()
 #' stop('foobar')
 #' }
-log_errors <- function(muffle=getOption("logger_muffle_errors", FALSE)) {
+log_errors <- function(muffle = getOption('logger_muffle_errors', FALSE)) {
         if (R.Version()$major >= 4) {
         globalCallingHandlers(
             error = function(m) {
                 logger::log_error(m$message)
-                if(isTRUE(muffle)) invokeRestart("abort")
+                if (isTRUE(muffle)) {
+                    invokeRestart('abort')
+                }
             }
         )
     } else {

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -37,16 +37,20 @@ log_messages <- function() {
 #' Injects a logger call to standard warnings
 #'
 #' This function uses \code{trace} to add a \code{log_warn} function call when \code{warning} is called to log the warning messages with the \code{logger} layout and appender.
+#' 
+#' @param muffle if TRUE, the warning are not shown after being logged
+#' 
 #' @export
 #' @examples \dontrun{
 #' log_warnings()
 #' for (i in 1:5) { Sys.sleep(runif(1)); warning(i) }
 #' }
-log_warnings <- function() {
+log_warnings <- function(muffle=getOption("logger_muffle_warnings", FALSE)) {
     if (R.Version()$major >= 4) {
         globalCallingHandlers(
             warning = function(m) {
                 logger::log_warn(m$message)
+                if(isTRUE(muffle)) invokeRestart("muffleWarning")
             }
         )
     } else {
@@ -63,16 +67,20 @@ log_warnings <- function() {
 #' Injects a logger call to standard errors
 #'
 #' This function uses \code{trace} to add a \code{log_error} function call when \code{stop} is called to log the error messages with the \code{logger} layout and appender.
+#' 
+#' @param muffle if TRUE, the errors are not thrown after being logged
+#' 
 #' @export
 #' @examples \dontrun{
 #' log_errors()
 #' stop('foobar')
 #' }
-log_errors <- function() {
+log_errors <- function(muffle=getOption("logger_muffle_errors", FALSE)) {
         if (R.Version()$major >= 4) {
         globalCallingHandlers(
             error = function(m) {
                 logger::log_error(m$message)
+                if(isTRUE(muffle)) invokeRestart("abort")
             }
         )
     } else {

--- a/man/log_errors.Rd
+++ b/man/log_errors.Rd
@@ -4,7 +4,10 @@
 \alias{log_errors}
 \title{Injects a logger call to standard errors}
 \usage{
-log_errors()
+log_errors(muffle = getOption("logger_muffle_errors", FALSE))
+}
+\arguments{
+\item{muffle}{if TRUE, the error is not thrown after being logged}
 }
 \description{
 This function uses \code{trace} to add a \code{log_error} function call when \code{stop} is called to log the error messages with the \code{logger} layout and appender.

--- a/man/log_warnings.Rd
+++ b/man/log_warnings.Rd
@@ -4,7 +4,10 @@
 \alias{log_warnings}
 \title{Injects a logger call to standard warnings}
 \usage{
-log_warnings()
+log_warnings(muffle = getOption("logger_muffle_warnings", FALSE))
+}
+\arguments{
+\item{muffle}{if TRUE, the warning is not shown after being logged}
 }
 \description{
 This function uses \code{trace} to add a \code{log_warn} function call when \code{warning} is called to log the warning messages with the \code{logger} layout and appender.


### PR DESCRIPTION
When you log a warning or an error, the condition is thrown again after the log message.

Therefore, here is a pull request to muffle these unnecessary messages.

I think it is really interesting for warnings, but I might have been carried away with errors, it might be not that useful. The `getOptions()`  part also.