### PR TITLE
Allow log_shiny_input_changes to have different init level

### DIFF
--- a/R/hooks.R
+++ b/R/hooks.R
@@ -132,7 +132,7 @@ log_shiny_input_changes <- function(input,
 
     input_values <- shiny::isolate(shiny::reactiveValuesToList(input))
     assignInMyNamespace('shiny_input_values', input_values)
-    log_info(skip_formatter(paste(
+    log_level(level, skip_formatter(paste(
         'Default Shiny inputs initialized:',
         as.character(jsonlite::toJSON(input_values, auto_unbox = TRUE)))), namespace = namespace)
 


### PR DESCRIPTION
Hi,

I wanted to use `logger::log_shiny_input_changes` in a Shiny-app we're building, but was bothered by the fact that the default shiny-inputs are logged at a static INFO-level. It would be nice if that was flexible. The current PR simply takes the level of the `level` argument provided by `log_shiny_input_changes` instead.

Is this something you'd be willing to consider?

I added some tests, but they rely on internal structure of the Shiny-package, as the function checks whether the shiny app `isRunning()`, and apparently and unfortunately it is _not_ within a `testServer`.