### PR TITLE
Fixes `log_{appender, threshold, layout, formatter}` error when called via `do.call`

### DIFF
--- a/R/logger.R
+++ b/R/logger.R
@@ -67,6 +67,18 @@ fallback_namespace <- function(namespace) {
     namespace
 }
 
+#' Assure valid fun_name
+#' @param fun_name string referencing current function name
+#' @param fallback_name string with fallback name if `fun_name` is invalid
+#' @keywords internal
+fallback_fun_name <- function(fun_name, fallback_name) {
+    fun_name_base <- strsplit(fun_name, '_')[[1]][2]
+    if (is.na(fun_name_base) || !is.character(fun_name_base)) {
+        return(fallback_name)
+    }
+    fun_name
+}
+
 #' Base Logging Function
 #' @param fun_name string a full name of log function
 #' @param arg see \code{\link{log_levels}}
@@ -134,7 +146,7 @@ log_config_setter <- function(fun_name, arg, namespace, index) {
 #' }
 #' @seealso \code{\link{logger}}, \code{\link{log_layout}}, \code{\link{log_formatter}}, \code{\link{log_appender}}
 log_threshold <- function(level = NULL, namespace = 'global', index = 1) {
-    fun_name <- deparse(sys.call()[[1]])
+    fun_name <- fallback_fun_name(deparse(sys.call()[[1]]), "log_threshold")
     log_config_setter(fun_name = fun_name, arg = level, namespace = namespace, index = index)
 }
 
@@ -149,7 +161,7 @@ log_threshold <- function(level = NULL, namespace = 'global', index = 1) {
 #' }
 #' @seealso \code{\link{logger}}, \code{\link{log_threshold}}, \code{\link{log_appender}} and \code{\link{log_formatter}}
 log_layout <- function(layout = NULL, namespace = 'global', index = 1) {
-    fun_name <- deparse(sys.call()[[1]])
+    fun_name <- fallback_fun_name(deparse(sys.call()[[1]]), "log_layout")
     log_config_setter(fun_name = fun_name, arg = layout, namespace = namespace, index = index)
 }
 
@@ -160,7 +172,7 @@ log_layout <- function(layout = NULL, namespace = 'global', index = 1) {
 #' @export
 #' @seealso \code{\link{logger}}, \code{\link{log_threshold}}, \code{\link{log_appender}} and \code{\link{log_layout}}
 log_formatter <- function(formatter = NULL, namespace = 'global', index = 1) {
-    fun_name <- deparse(sys.call()[[1]])
+    fun_name <- fallback_fun_name(deparse(sys.call()[[1]]), "log_formatter")
     log_config_setter(fun_name = fun_name, arg = formatter, namespace = namespace, index = index)
 }
 
@@ -186,7 +198,7 @@ log_formatter <- function(formatter = NULL, namespace = 'global', index = 1) {
 #' }
 #' @seealso \code{\link{logger}}, \code{\link{log_threshold}}, \code{\link{log_layout}} and \code{\link{log_formatter}}
 log_appender <- function(appender = NULL, namespace = 'global', index = 1) {
-    fun_name <- deparse(sys.call()[[1]])
+    fun_name <- fallback_fun_name(deparse(sys.call()[[1]]), "log_appender")
     log_config_setter(fun_name = fun_name, arg = appender, namespace = namespace, index = index)
 }
 

--- a/tests/testthat/test-logger.R
+++ b/tests/testthat/test-logger.R
@@ -111,6 +111,82 @@ test_that('print.level', {
     expect_equal(capture.output(print(INFO)), 'Log level: INFO')
 })
 
+test_that("log_appender `do.call` works the same as calling function", {
+  t <- tempfile()
+
+  old_value <- log_appender()
+
+  log_info("42")
+
+  do.call(
+    log_appender,
+    list(
+      appender_file(t)
+    )
+  ) |>
+    expect_no_error()
+
+  log_info("42")
+
+  expect_length(readLines(t), 2)
+
+  log_appender(old_value)
+})
+
+test_that("log_threshold `do.call` works the same as calling function", {
+  t <- tempfile()
+  old_appender <- log_appender()
+  log_appender(appender_file(t))
+  log_threshold(INFO)
+
+  old_value <- log_threshold()
+
+  log_info("42")
+
+  do.call(
+    log_threshold,
+    list(
+      WARN
+    )
+  ) |>
+    expect_no_error()
+
+  log_info("42")
+
+  expect_length(readLines(t), 1)
+
+  log_appender(old_appender)
+  log_threshold(old_value)
+})
+
+testthat::test_that("log_formatter `do.call` works the same as calling function", {
+  old_value <- log_formatter()
+
+  do.call(
+    log_formatter,
+    list(
+      formatter_paste
+    )
+  ) |>
+    expect_no_error()
+
+  log_formatter(old_value)
+})
+
+testthat::test_that("log_layout `do.call` works the same as calling function", {
+  old_value <- log_layout()
+
+  do.call(
+    log_layout,
+    list(
+      formatter_paste
+    )
+  ) |>
+    expect_no_error()
+
+  log_layout(old_value)
+})
+
 ## reset settings
 log_threshold(threshold)
 log_layout(layout)


### PR DESCRIPTION
- Closes #120 

### Changes description

- Validates `fun_name` before `log_config_setter` call
- Adds tests for the original issue
