### PR TITLE
New arguments for `log_shiny_input_changes`

### DIFF
--- a/man/log_shiny_input_changes.Rd
+++ b/man/log_shiny_input_changes.Rd
@@ -8,7 +8,10 @@ log_shiny_input_changes(
   input,
   level = INFO,
   namespace = NA_character_,
-  excluded_inputs = character()
+  excluded_inputs = character(),
+  allow = FALSE,
+  change_message = "Shiny input change detected on {name}: {old} -> {new}",
+  initialize_message = "Default Shiny inputs initialized:"
 )
 }
 \arguments{
@@ -19,6 +22,14 @@ log_shiny_input_changes(
 \item{namespace}{the name of the namespace}
 
 \item{excluded_inputs}{character vector of input names to exclude from logging}
+
+\item{allow}{allow to be used outside Shiny app}
+
+\item{change_message}{custom message to be displayed during the input change - supports `glue` syntax where `{name}`
+is the name of the input, and `{old}` and `{new}` are input values before the change and after the change}
+
+\item{initialize_message}{custom message to be displayed during input initialization (this is followed by initialized
+input values being printed in JSON format)}
 }
 \description{
 This is to be called in the \code{server} section of the Shiny app.


### PR DESCRIPTION
This PR introduces 3 new parameters

```r
#' @param allow allow to be used outside Shiny app
#' @param change_message custom message to be displayed during the input change - supports `glue` syntax where `{name}`
#' is the name of the input, and `{old}` and `{new}` are input values before the change and after the change
#' @param initialize_message custom message to be displayed during input initialization (this is followed by initialized
#' input values being printed in JSON format)
```

# `@param allow`

`allow` is needed to skip the `stop()` statement that blocks the usage of `log_shiny_input_changes` outside of Shiny app. However there are use cases where the usage outside Shiny app make sense, e.g. in Shiny Tests: 

```r
library(shiny)
server <- function(input, output, session) {
  logger::log_shiny_input_changes()
  x <- reactive(input$a * input$b)
}

testServer(server, {
  session$setInputs(a = 2, b = 3)
  stopifnot(x() == 6)
})
Error in logger::log_shiny_input_changes() :
No Shiny app running, it makes no sense to call this function outside of a Shiny app
```

# `@param *_message`

If there is multiple server modules that utilize `log_shiny_input_changes` with similar input names, it would be beneficial to be able to append the `log_shiny_input_changes` messages with user-defined messages (e.g. such messages that include name of the function in the message). So I proposed to have messages used in this function as parameters that a user can overwrite.
