### PR TITLE
Fixes order of arguments in examples match the formals

### DIFF
--- a/R/color.R
+++ b/R/color.R
@@ -5,15 +5,14 @@
 #' @param level see \code{\link{log_levels}}
 #' @return string with ANSI escape code
 #' @export
-#' @examples \dontrun{
-#' cat(colorize_by_log_level(FATAL, 'foobar'), '\n')
-#' cat(colorize_by_log_level(ERROR, 'foobar'), '\n')
-#' cat(colorize_by_log_level(WARN, 'foobar'), '\n')
-#' cat(colorize_by_log_level(SUCCESS, 'foobar'), '\n')
-#' cat(colorize_by_log_level(INFO, 'foobar'), '\n')
-#' cat(colorize_by_log_level(DEBUG, 'foobar'), '\n')
-#' cat(colorize_by_log_level(TRACE, 'foobar'), '\n')
-#' }
+#' @examplesIf requireNamespace("crayon")
+#' cat(colorize_by_log_level('foobar', FATAL), '\n')
+#' cat(colorize_by_log_level('foobar', ERROR), '\n')
+#' cat(colorize_by_log_level('foobar', WARN), '\n')
+#' cat(colorize_by_log_level('foobar', SUCCESS), '\n')
+#' cat(colorize_by_log_level('foobar', INFO), '\n')
+#' cat(colorize_by_log_level('foobar', DEBUG), '\n')
+#' cat(colorize_by_log_level('foobar', TRACE), '\n')
 colorize_by_log_level <- function(msg, level) {
 
     fail_on_missing_package('crayon')
@@ -42,15 +41,14 @@ colorize_by_log_level <- function(msg, level) {
 #' @param level see \code{\link{log_levels}}
 #' @return string with ANSI escape code
 #' @export
-#' @examples \dontrun{
-#' cat(grayscale_by_log_level(FATAL, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(ERROR, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(WARN, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(SUCCESS, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(INFO, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(DEBUG, 'foobar'), '\n')
-#' cat(grayscale_by_log_level(TRACE, 'foobar'), '\n')
-#' }
+#' @examplesIf requireNamespace("crayon")
+#' cat(grayscale_by_log_level('foobar', FATAL), '\n')
+#' cat(grayscale_by_log_level('foobar', ERROR), '\n')
+#' cat(grayscale_by_log_level('foobar', WARN), '\n')
+#' cat(grayscale_by_log_level('foobar', SUCCESS), '\n')
+#' cat(grayscale_by_log_level('foobar', INFO), '\n')
+#' cat(grayscale_by_log_level('foobar', DEBUG), '\n')
+#' cat(grayscale_by_log_level('foobar', TRACE), '\n')
 grayscale_by_log_level <- function(msg, level) {
 
     fail_on_missing_package('crayon')

--- a/man/colorize_by_log_level.Rd
+++ b/man/colorize_by_log_level.Rd
@@ -18,13 +18,13 @@ string with ANSI escape code
 Adding color to a string to be used in terminal output. Supports ANSI standard colors 8 or 256.
 }
 \examples{
-\dontrun{
-cat(colorize_by_log_level(FATAL, 'foobar'), '\n')
-cat(colorize_by_log_level(ERROR, 'foobar'), '\n')
-cat(colorize_by_log_level(WARN, 'foobar'), '\n')
-cat(colorize_by_log_level(SUCCESS, 'foobar'), '\n')
-cat(colorize_by_log_level(INFO, 'foobar'), '\n')
-cat(colorize_by_log_level(DEBUG, 'foobar'), '\n')
-cat(colorize_by_log_level(TRACE, 'foobar'), '\n')
-}
+\dontshow{if (requireNamespace("crayon")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+cat(colorize_by_log_level('foobar', FATAL), '\n')
+cat(colorize_by_log_level('foobar', ERROR), '\n')
+cat(colorize_by_log_level('foobar', WARN), '\n')
+cat(colorize_by_log_level('foobar', SUCCESS), '\n')
+cat(colorize_by_log_level('foobar', INFO), '\n')
+cat(colorize_by_log_level('foobar', DEBUG), '\n')
+cat(colorize_by_log_level('foobar', TRACE), '\n')
+\dontshow{\}) # examplesIf}
 }

--- a/man/grayscale_by_log_level.Rd
+++ b/man/grayscale_by_log_level.Rd
@@ -18,13 +18,13 @@ string with ANSI escape code
 Adding color to a string to be used in terminal output. Supports ANSI standard colors 8 or 256.
 }
 \examples{
-\dontrun{
-cat(grayscale_by_log_level(FATAL, 'foobar'), '\n')
-cat(grayscale_by_log_level(ERROR, 'foobar'), '\n')
-cat(grayscale_by_log_level(WARN, 'foobar'), '\n')
-cat(grayscale_by_log_level(SUCCESS, 'foobar'), '\n')
-cat(grayscale_by_log_level(INFO, 'foobar'), '\n')
-cat(grayscale_by_log_level(DEBUG, 'foobar'), '\n')
-cat(grayscale_by_log_level(TRACE, 'foobar'), '\n')
-}
+\dontshow{if (requireNamespace("crayon")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+cat(grayscale_by_log_level('foobar', FATAL), '\n')
+cat(grayscale_by_log_level('foobar', ERROR), '\n')
+cat(grayscale_by_log_level('foobar', WARN), '\n')
+cat(grayscale_by_log_level('foobar', SUCCESS), '\n')
+cat(grayscale_by_log_level('foobar', INFO), '\n')
+cat(grayscale_by_log_level('foobar', DEBUG), '\n')
+cat(grayscale_by_log_level('foobar', TRACE), '\n')
+\dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
### Changes description

- Fix examples on `grayscale_by_log_level` and `colorize_by_log_level` 
  - The order of arguments in examples didn't match formals
- Uses `@examplesIf` tag to prevent examples from running when `{crayon}` is not installed
  - Prevents issue for happening again while still protected against suggested dependency not being installed

note: I see that all of the examples on the package are surrounded by `\dontrun`, if you prefer to keep it like that here, let me know and I'll revert to it.