### PR TITLE
`use_dev_version()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     )
 Title: A Lightweight, Modern and Flexible Logging Utility
 Description: Inspired by the the 'futile.logger' R package and 'logging' Python module, this utility provides a flexible and extensible way of formatting and delivering log messages with low overhead.
-Version: 0.3.0
+Version: 0.3.0.9000
 Date: 2024-03-03
 URL: https://daroczig.github.io/logger/
 BugReports: https://github.com/daroczig/logger/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# logger (development version)
+
 # logger 0.3.0 (2024-03-03)
 
 Many unrelated small features, fixes and documentation updates collected over 2+ years.


### PR DESCRIPTION
Looks like this slipped your mind after the last release.