### PR TITLE
Use `withCallingHandlers()` in `log_failure()`

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -232,8 +232,10 @@ tictocs <- new.env()
 #' log_failure(foobar)
 #' }
 log_failure <- function(expression) {
-  tryCatch(expression, error = function(e) {
-    log_error(e$message)
-    stop(e)
-  })
+  withCallingHandlers(
+    expression,
+    error = function(e) {
+      log_error(conditionMessage(e))
+    }
+  )
 }


### PR DESCRIPTION
It's more appropriate to use `withCallingHandlers()` here because we want to add a side-effect, not change the return value. I doubt this will have much impact in practice, but it does make the tracebacks from errors in `log_failure()` a little simpler.