### PR TITLE
Use mirai for Async Appender

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Suggests:
     glue,
     jsonlite,
     knitr,
-    mirai,
+    mirai (>= 1.3.0),
     pander,
     parallel,
     R.utils,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,13 +22,13 @@ Imports:
     utils
 Suggests:
     botor,
-    callr,
     covr,
     crayon,
     devtools,
     glue,
     jsonlite,
     knitr,
+    mirai,
     pander,
     parallel,
     R.utils,
@@ -41,7 +41,6 @@ Suggests:
     syslognet,
     telegram,
     testthat (>= 3.0.0),
-    txtq,
     withr
 Enhances:
     futile.logger,

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * computing metadata lazily, so various expensive computations are only performed if you actually add them to the log (#105, @hadley)
 * `log_appender()`, `log_layout()` and `log_formatter()` now check that you are calling them with a function, and return the previously set value (#170, @hadley)
 * new function to return number of log indices (#194, @WurmPeter)
+* `appender_async` is now using `mirai` instead of a custom background process and queue system (#214, @hadley @shikokuchuo)
 
 ## Fixes
 

--- a/R/appenders.R
+++ b/R/appenders.R
@@ -391,7 +391,7 @@ appender_async <- function(appender,
 
   # Start one background process (hence dispatcher not required)
   # force = FALSE allows multiple appenders to use same namespace logger
-  mirai::daemons(1L, dispatcher = FALSE, force = FALSE, .compute = namespace)
+  mirai::daemons(1L, dispatcher = "none", force = FALSE, .compute = namespace)
   mirai::everywhere(
     {
       library(logger)
@@ -404,7 +404,7 @@ appender_async <- function(appender,
 
   structure(
     function(lines) {
-      m <- mirai::mirai(
+      mirai::mirai(
         for (line in lines) {
           appender(line)
         },

--- a/R/appenders.R
+++ b/R/appenders.R
@@ -408,7 +408,7 @@ appender_async <- function(appender,
         for (line in lines) {
           appender(line)
         },
-        lines = lines,
+        .args = list(lines = lines),
         .compute = namespace
       )
     },

--- a/inst/load-packages-in-background-process.R
+++ b/inst/load-packages-in-background-process.R
@@ -1,4 +1,0 @@
-## this is to be called in the background process of appender_async
-## because having library/require calls in that function throws false R CMD check alerts
-require("logger")
-require("txtq")

--- a/man/appender_async.Rd
+++ b/man/appender_async.Rd
@@ -7,7 +7,6 @@ background process to avoid blocking the main R session}
 \usage{
 appender_async(
   appender,
-  batch = 1,
   namespace = "async_logger",
   init = function() log_info("Background process started")
 )
@@ -16,8 +15,6 @@ appender_async(
 \item{appender}{a \code{\link[=log_appender]{log_appender()}} function with a \code{generator}
 attribute (TODO note not required, all fn will be passed if
 not)}
-
-\item{batch}{number of records to process from the queue at once}
 
 \item{namespace}{\code{logger} namespace to use for logging messages on
 starting up the background process}
@@ -35,10 +32,7 @@ Delays executing the actual appender function to the future in a
 background process to avoid blocking the main R session
 }
 \note{
-This functionality depends on the \pkg{txtq} and \pkg{callr}
-packages. The R session's temp folder is used for staging files
-(message queue and other forms of communication between the
-parent and child processes).
+This functionality depends on the \pkg{mirai} package.
 }
 \examples{
 \dontrun{
@@ -57,10 +51,9 @@ log_appender(appender_console, namespace = "async_logger")
 ## start async appender
 t <- tempfile()
 log_info("Logging in the background to {t}")
-my_appender <- appender_async(appender_file_slow(file = t))
 
 ## use async appender
-log_appender(my_appender)
+log_appender(appender_async(appender_file_slow(file = t)))
 log_info("Was this slow?")
 system.time(for (i in 1:25) log_info(i))
 
@@ -68,17 +61,6 @@ readLines(t)
 Sys.sleep(10)
 readLines(t)
 
-## check on the async appender (debugging, you will probably never need this)
-attr(my_appender, "async_writer_queue")$count()
-attr(my_appender, "async_writer_queue")$log()
-
-attr(my_appender, "async_writer_process")$get_pid()
-attr(my_appender, "async_writer_process")$get_state()
-attr(my_appender, "async_writer_process")$poll_process(1)
-attr(my_appender, "async_writer_process")$read()
-
-attr(my_appender, "async_writer_process")$is_alive()
-attr(my_appender, "async_writer_process")$read_error()
 }
 }
 \seealso{

--- a/tests/testthat/_snaps/CRANSKIP-logger-namespaces.md
+++ b/tests/testthat/_snaps/CRANSKIP-logger-namespaces.md
@@ -14,7 +14,7 @@
     Code
       log_info("foobar")
     Output
-      logger / global / logger / eval / eval(expr, envir, enclos)
+      logger / global / logger / eval / eval(expr, envir)
     Code
       f()
     Output

--- a/tests/testthat/test-CRANSKIP-appenders.R
+++ b/tests/testthat/test-CRANSKIP-appenders.R
@@ -8,7 +8,7 @@ test_that("async logging", {
   )
 
   for (i in 1:5) log_info(i)
-  Sys.sleep(0.25)
+  Sys.sleep(0.5)
 
   expect_equal(readLines(t)[1], "1")
   expect_equal(length(readLines(t)), 5)

--- a/tests/testthat/test-CRANSKIP-appenders.R
+++ b/tests/testthat/test-CRANSKIP-appenders.R
@@ -9,6 +9,7 @@ test_that("async logging", {
 
   for (i in 1:5) log_info(i)
   Sys.sleep(0.25)
+
   expect_equal(readLines(t)[1], "1")
   expect_equal(length(readLines(t)), 5)
 })

--- a/tests/testthat/test-CRANSKIP-appenders.R
+++ b/tests/testthat/test-CRANSKIP-appenders.R
@@ -8,7 +8,7 @@ test_that("async logging", {
   )
 
   for (i in 1:5) log_info(i)
-  Sys.sleep(0.5)
+  Sys.sleep(1)
 
   expect_equal(readLines(t)[1], "1")
   expect_equal(length(readLines(t)), 5)

--- a/vignettes/performance.Rmd
+++ b/vignettes/performance.Rmd
@@ -101,12 +101,12 @@ log_appender(appender_async(appender_file_slow(file = tempfile())))
 
 async <- function() log_info('Was this slow?')
 microbenchmark(async(), times = 1e3)
-#> Unit: microseconds
-#>     expr     min      lq     mean   median     uq      max neval
-#>  async() 511.329 528.247 614.8694 558.2535 616.14 5018.731  1000
+# Unit: microseconds
+#     expr     min       lq     mean  median      uq     max neval
+#  async() 298.275 315.5565 329.6235 322.219 333.371 894.579  1000
 ```
 
-Please note that although this ~0.6 ms is significantly higher than the ~0.15 ms we achieved above with the `sprintf` formatter, but this time we are calling an appender that would take 1 full second to deliver the log message (and not just printing to the console), so bringing that down to less than 1 millisecond is not too bad. If you need even higher throughput, then a custom `appender_async` without checking on the background process and potentially a faster message queue can bring this even below to 200 µs.
+Please note that although this ~0.3 ms is higher than the ~0.15 ms we achieved above with the `sprintf` formatter, but this time we are calling an appender that would take 1 full second to deliver the log message (and not just printing to the console), so bringing that down to less than 1 millisecond is not too bad.
 
 ```{r cleanup, include = FALSE}
 logger:::namespaces_reset()


### PR DESCRIPTION
Thanks for pointing me to this @daroczig!

Rebases and adds a commit to @hadley's #208 with more efficiency in the setup.

It also maps the logger namespace to mirai's 'compute profile', basically the same concept.

This checks fine for me. The snapshot test error seems unrelated (I'm also getting this locally running off main).

One thing to note is that the background process isn't terminated. This is not a problem in real life as it will automatically terminate when the main session ends, but you should be aware if attempting to test on CRAN for instance. You'd need to add a `daemons(0L, .compute = namespace)` somewhere in the teardown.
