### PR TITLE
Update mirai::daemons() arguments

### DIFF
--- a/R/appenders.R
+++ b/R/appenders.R
@@ -391,7 +391,7 @@ appender_async <- function(appender,
 
   # Start one background process (hence dispatcher not required)
   # force = FALSE allows multiple appenders to use same namespace logger
-  mirai::daemons(1L, dispatcher = "none", force = FALSE, .compute = namespace)
+  mirai::daemons(1L, dispatcher = FALSE, force = FALSE, cleanup = FALSE, .compute = namespace)
   mirai::everywhere(
     {
       library(logger)


### PR DESCRIPTION
Really minimal changes:
 - dispatcher argument reverts to a logical value post mirai v2 (also accepted previously)
 - set cleanup to FALSE for more efficiency as there is no need to reset after each evaluation

No urgency in applying these as the current values will continue to be supported for a while.