### PR TITLE
Add traceback support in log_errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * `log_appender()`, `log_layout()` and `log_formatter()` now check that you are calling them with a function, and return the previously set value (#170, @hadley)
 * new function to return number of log indices (#194, @WurmPeter)
 * `appender_async` is now using `mirai` instead of a custom background process and queue system (#214, @hadley @shikokuchuo)
+* `log_errors()` gains a `traceback` argument that toggles whether the error traceback should be logged along with the message (#86, @thomasp85)
 
 ## Fixes
 

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -94,7 +94,7 @@ log_errors <- function(muffle = getOption("logger_muffle_errors", FALSE), traceb
               line <- paste(unique(c(ref[1L], ref[3L])), collapse = "-")
               msg <- paste0(msg, " at ", file, " #", line)
             }
-            logger::log_level(logger::ERROR, msg, .topcall = m$call)
+            logger::log_level(logger::ERROR, skip_formatter(msg), .topcall = m$call)
           }
         }
         if (isTRUE(muffle)) {

--- a/man/log_errors.Rd
+++ b/man/log_errors.Rd
@@ -4,10 +4,16 @@
 \alias{log_errors}
 \title{Injects a logger call to standard errors}
 \usage{
-log_errors(muffle = getOption("logger_muffle_errors", FALSE))
+log_errors(
+  muffle = getOption("logger_muffle_errors", FALSE),
+  traceback = FALSE
+)
 }
 \arguments{
 \item{muffle}{if TRUE, the error is not thrown after being logged}
+
+\item{traceback}{if TRUE the error traceback is logged along with the error
+message}
 }
 \description{
 This function uses \code{\link[=trace]{trace()}} to add a \code{\link[=log_error]{log_error()}} function call when

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -33,7 +33,7 @@
     Output
       ERROR I'm failing
       ERROR Traceback:
-      ERROR 2: stop("I'm failing") at helper.R #41
+      ERROR 2: stop("I'm failing") at helper.R #46
       ERROR 1: function_that_fails()
 
 # shiny input initialization is detected

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -27,6 +27,14 @@
       writeLines(eval_outside("log_errors()", "f<-function(x) {42 * \"foobar\"}; f()"))
     Output
       ERROR non-numeric argument to binary operator
+    Code
+      writeLines(eval_outside("log_errors(traceback = TRUE)",
+        "f<-function() stop(\"TEST\"); f()"))
+    Output
+      ERROR TEST
+      ERROR Traceback:
+      ERROR 2: stop("TEST")
+      ERROR 1: f()
 
 # shiny input initialization is detected
 

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -29,12 +29,12 @@
       ERROR non-numeric argument to binary operator
     Code
       writeLines(eval_outside("log_errors(traceback = TRUE)",
-        "f<-function() stop(\"TEST\"); f()"))
+        "source(\"helper.R\", keep.source = TRUE)", "function_that_fails()"))
     Output
-      ERROR TEST
+      ERROR I'm failing
       ERROR Traceback:
-      ERROR 2: stop("TEST")
-      ERROR 1: f()
+      ERROR 2: stop("I'm failing") at helper.R #41
+      ERROR 1: function_that_fails()
 
 # shiny input initialization is detected
 

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -33,7 +33,7 @@
     Output
       ERROR I'm failing
       ERROR Traceback:
-      ERROR 2: stop("I'm failing") at helper.R #46
+      ERROR 2: stop("I'm failing") at helper.R #45
       ERROR 1: function_that_fails()
 
 # shiny input initialization is detected

--- a/tests/testthat/_snaps/hooks.md
+++ b/tests/testthat/_snaps/hooks.md
@@ -33,7 +33,7 @@
     Output
       ERROR I'm failing
       ERROR Traceback:
-      ERROR 2: stop("I'm failing") at helper.R #45
+      ERROR 2: stop("I'm failing") at helper.R #46
       ERROR 1: function_that_fails()
 
 # shiny input initialization is detected

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -35,3 +35,8 @@ eval_outside <- function(...) {
   suppressWarnings(system2(path, input, stdout = TRUE, stderr = TRUE))
   readLines(output)
 }
+
+# This function is needed to test traceback logging
+function_that_fails <- function() {
+  stop("I'm failing")
+}

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -16,8 +16,8 @@ test_that("log_errors", {
     writeLines(eval_outside("log_errors()", "foobar"))
     writeLines(eval_outside("log_errors()", 'f<-function(x) {42 * "foobar"}; f()'))
     writeLines(eval_outside(
-      "log_errors(traceback = TRUE)", 
-      'source("helper.R", keep.source = TRUE)', 
+      "log_errors(traceback = TRUE)",
+      'source("helper.R", keep.source = TRUE)',
       "function_that_fails()"))
   })
 })

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -15,6 +15,7 @@ test_that("log_errors", {
     writeLines(eval_outside("log_errors()", "stop(42)"))
     writeLines(eval_outside("log_errors()", "foobar"))
     writeLines(eval_outside("log_errors()", 'f<-function(x) {42 * "foobar"}; f()'))
+    writeLines(eval_outside("log_errors(traceback = TRUE)", 'f<-function() stop("TEST"); f()'))
   })
 })
 

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -15,7 +15,10 @@ test_that("log_errors", {
     writeLines(eval_outside("log_errors()", "stop(42)"))
     writeLines(eval_outside("log_errors()", "foobar"))
     writeLines(eval_outside("log_errors()", 'f<-function(x) {42 * "foobar"}; f()'))
-    writeLines(eval_outside("log_errors(traceback = TRUE)", 'source("helper.R", keep.source = TRUE)', "function_that_fails()"))
+    writeLines(eval_outside(
+      "log_errors(traceback = TRUE)", 
+      'source("helper.R", keep.source = TRUE)', 
+      "function_that_fails()"))
   })
 })
 

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -15,10 +15,9 @@ test_that("log_errors", {
     writeLines(eval_outside("log_errors()", "stop(42)"))
     writeLines(eval_outside("log_errors()", "foobar"))
     writeLines(eval_outside("log_errors()", 'f<-function(x) {42 * "foobar"}; f()'))
-    writeLines(eval_outside(
-      "log_errors(traceback = TRUE)",
-      'source("helper.R", keep.source = TRUE)',
-      "function_that_fails()"))
+    writeLines(eval_outside("log_errors(traceback = TRUE)",
+                            'source("helper.R", keep.source = TRUE)',
+                            "function_that_fails()"))
   })
 })
 

--- a/tests/testthat/test-hooks.R
+++ b/tests/testthat/test-hooks.R
@@ -15,7 +15,7 @@ test_that("log_errors", {
     writeLines(eval_outside("log_errors()", "stop(42)"))
     writeLines(eval_outside("log_errors()", "foobar"))
     writeLines(eval_outside("log_errors()", 'f<-function(x) {42 * "foobar"}; f()'))
-    writeLines(eval_outside("log_errors(traceback = TRUE)", 'f<-function() stop("TEST"); f()'))
+    writeLines(eval_outside("log_errors(traceback = TRUE)", 'source("helper.R", keep.source = TRUE)', "function_that_fails()"))
   })
 })
 


### PR DESCRIPTION
Fix #86 

This PR could be improved if we used rlang's traceback formatting, but I'll leave the decision to take on that dependency to you (as it is a dependency of the tidyverse I don't think it will have a negative effect in any way to use it)