### PR TITLE
feat: format timestamp

### DIFF
--- a/R/layouts.R
+++ b/R/layouts.R
@@ -150,7 +150,18 @@ layout_simple <- function(level,
                           .logcall = sys.call(),
                           .topcall = sys.call(-1),
                           .topenv = parent.frame()) {
-  paste0(attr(level, "level"), " [", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "] ", msg)
+  timestamp <- logger_meta_env(
+    log_level = level,
+    namespace = namespace,
+    .logcall = .logcall,
+    .topcall = .topcall,
+    .topenv = .topenv
+  )$time
+  paste0(attr(level, "level"), " [", if (is.character(timestamp)) {
+    timestamp
+  } else {
+    format(timestamp, "%Y-%m-%d %H:%M:%S")
+  }, "] ", msg)
 }
 attr(layout_simple, "generator") <- quote(layout_simple())
 
@@ -184,8 +195,14 @@ layout_logging <- function(level,
     .topcall = .topcall,
     .topenv = .topenv
   )
+  timestamp <- meta$time
   paste0(
-    format(Sys.time(), "%Y-%m-%d %H:%M:%S"), " ",
+    if (is.character(timestamp)) {
+      timestamp
+    } else {
+      format(timestamp, "%Y-%m-%d %H:%M:%S")
+    },
+    " ",
     attr(level, "level"), ":",
     ifelse(meta$ns == "global", "", meta$ns), ":",
     msg

--- a/R/logger-meta.R
+++ b/R/logger-meta.R
@@ -16,7 +16,14 @@ logger_meta_env <- function(log_level = NULL,
   delayedAssign("call", deparse_to_one_line(.topcall), assign.env = env)
   delayedAssign("topenv", top_env_name(.topenv), assign.env = env)
 
-  env$time <- timestamp
+  format_time <- getOption(
+    paste0("logger.format_time.", namespace), # prefer namespace-specific option
+    default = getOption(
+      "logger.format_time", # fallback to global option
+      default = identity # if no options, keep it POSIXct for the backward compatibility
+    )
+  )
+  env$time <- format_time(timestamp)
   env$levelr <- log_level
   env$level <- attr(log_level, "level")
 

--- a/tests/testthat/_snaps/layouts.md
+++ b/tests/testthat/_snaps/layouts.md
@@ -73,3 +73,31 @@
     Output
       logger.tester INFO everything =  42
 
+# timestamp can be formatted
+
+    Code
+      log_info()
+    Output
+      global UTC
+
+---
+
+    Code
+      log_info()
+    Output
+      INFO [global UTC] []
+
+---
+
+    Code
+      log_info()
+    Output
+      global UTC INFO:logger:[]
+
+---
+
+    Code
+      log_info()
+    Output
+      {"time":"global UTC","msg":"[]"}
+

--- a/tests/testthat/test-layouts.R
+++ b/tests/testthat/test-layouts.R
@@ -94,3 +94,25 @@ test_that("log_info() captures package info", {
     logger_info_tester_function("everything = ")
   })
 })
+
+test_that("timestamp can be formatted", {
+  layouts <- list(
+    layout_glue_generator("{time}"),
+    # layout_blank, # blank layout does not print time
+    layout_simple,
+    layout_logging,
+    # layout_glue, # time-foramt is fixed
+    # layout_glue_colors, # time-foramt is fixed
+    layout_json(fields = "time")
+  )
+
+  withr::with_options(
+    list(`logger.format_time` = function(x) format(x, "global %Z", tz = "UTC")),
+    {
+      for (layout in layouts) {
+        local_test_logger(layout = layout, formatter = formatter_json)
+        expect_snapshot(log_info())
+      }
+    }
+  )
+})

--- a/tests/testthat/test-logger-meta.R
+++ b/tests/testthat/test-logger-meta.R
@@ -32,3 +32,37 @@ test_that("captures other environmental metadata", {
   expect_equal(env$os_version, sysinfo$version)
   expect_equal(env$user, sysinfo$user)
 })
+
+test_that("format timestamp", {
+  option_global_ns <- list(`logger.format_time` = function(x) format(x, "global %Z", tz = "UTC"))
+
+  # If no namespace-specific option, fallback to global
+  expect_equal(
+    withr::with_options(
+      c(option_global_ns, list(`logger.format_time.foo` = NULL)),
+      logger_meta_env(namespace = "foo")$time
+    ),
+    "global UTC"
+  )
+
+  # If namespace-specific option is set, use it
+  expect_equal(
+    withr::with_options(
+      c(
+        option_global_ns,
+        list(`logger.format_time.foo` = function(x) format(x, "foo %Z", tz = "UTC"))
+      ),
+      logger_meta_env(namespace = "foo")$time
+    ),
+    "foo UTC"
+  )
+
+  # If both options are unset, keep POSIXct
+  expect_equal(
+    withr::with_options(
+      list(`logger.format_time` = NULL, `logger.format_time.foo` = NULL),
+      class(logger_meta_env(namespace = "foo")$time)
+    ),
+    c("POSIXct", "POSIXt")
+  )
+})


### PR DESCRIPTION
This PR enables formatting timestamp of logs by specifying functions to the following options

- `logger.format_time`
- `logger.format_time.{namespace}` (has priority)

I actually wanted to achieve the feature without using options, but I find no suitable place to implement it...

Note that the behavior is not yet documented because I am not sure where to document it.
Do you have any ideas?

Some use cases are below

- modifying timezone
- get sub-second precision

```
withr::with_options(
  list(`logger.format_time` = function(x) format(x, "%Y-%m-%d %H:%M:%OS6 %Z", tz = "UTC")),
  {
    logger::log_formatter(logger::formatter_logging)
    logger::log_layout(logger::layout_logging)
    logger::log_info("foo")

    logger::log_formatter(logger::formatter_json)
    logger::log_layout(logger::layout_json_parser(fields = "time"))
    logger::log_warn(message = "foo")
  }
)
2025-01-25 14:45:39.519480 UTC INFO::foo
{"time":"2025-01-25 14:45:39.565330 UTC","message":"foo"}
```