### PR TITLE
Update for mirai 2.1.0

### DIFF
--- a/R/appenders.R
+++ b/R/appenders.R
@@ -389,9 +389,10 @@ appender_async <- function(appender,
   fail_on_missing_package("mirai")
   force(appender)
 
-  # Start one background process (hence dispatcher not required)
-  # force = FALSE allows multiple appenders to use same namespace logger
-  mirai::daemons(1L, dispatcher = FALSE, force = FALSE, cleanup = FALSE, .compute = namespace)
+  # Start one non-dispatcher background process if not already started
+  if (is.null(mirai::nextget("n", .compute = namespace))) {
+    mirai::daemons(1L, dispatcher = FALSE, cleanup = FALSE, .compute = namespace)
+  }
   mirai::everywhere(
     {
       library(logger)


### PR DESCRIPTION
It now errors for mirai attempting to set `daemons()` on the same compute profile without an explicit `daemons(0)` reset.

Normally packages using mirai should not set daemons themselves as per https://mirai.r-lib.org/articles/mirai.html#using-mirai-in-a-package but the use in logger is known and explicitly excepted.

Hi @daroczig I was just checking through revdeps and I realise I should have submitted this to you sooner. It's a rather niche case I think - only applicable if 2 async appenders try to use the same namespace (not even sure that's 'valid'). Thanks!